### PR TITLE
Prevented e-mail template from being rendered by Helm

### DIFF
--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -10,7 +10,7 @@ name: orb
 description: Orb Observability Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 1.0.9
+version: 1.0.10
 appVersion: "0.9.0"
 home: https://getorb.io
 sources:

--- a/charts/orb/files/email.tmpl
+++ b/charts/orb/files/email.tmpl
@@ -1,0 +1,8 @@
+To: {{index .To 0}}
+From: {{.From}}
+Subject: {{.Subject}}
+{{.Header}}
+You have initiated password reset.
+Follow the link below to reset password.
+{{.Content}}
+{{.Footer}}

--- a/charts/orb/templates/users-deployment.yaml
+++ b/charts/orb/templates/users-deployment.yaml
@@ -6,15 +6,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-users-config
 data:
-  email.tmpl: |
-    To: {{.To}}
-    From: {{.From}}
-    Subject: {{.Subject}}
-    {{.Header}}
-    You have initiated password reset.
-    Follow the link below to reset password.
-    {{.Content}}
-  {{.Footer}}
+  email.tmpl: {{ .Files.Get "files/email.tmpl" | quote}}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
The issue was that Helm was rendering the email template. So when the users service attempted to input values in the email template, there was no template variables to replace.