### PR TITLE
[FIX] adding possibility to inject annotations on pods

### DIFF
--- a/charts/orb/templates/auth-deployment.yaml
+++ b/charts/orb/templates/auth-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       component: auth
   template:
     metadata:
+      {{- with .Values.auth.metadata.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: auth

--- a/charts/orb/templates/fleet-deployment.yaml
+++ b/charts/orb/templates/fleet-deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         commit_sha: {{ .Values.defaults.image.commitHash }}
+      {{- with .Values.fleet.metadata.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: fleet

--- a/charts/orb/templates/policies-deployment.yaml
+++ b/charts/orb/templates/policies-deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         commit_sha: {{ .Values.defaults.image.commitHash }}
+      {{- with .Values.policies.metadata.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: policies

--- a/charts/orb/templates/sinker-deployment.yaml
+++ b/charts/orb/templates/sinker-deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         commit_sha: {{ .Values.defaults.image.commitHash }}
+      {{- with .Values.sinker.metadata.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: sinker

--- a/charts/orb/templates/sinks-deployment.yaml
+++ b/charts/orb/templates/sinks-deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         commit_sha: {{ .Values.defaults.image.commitHash }}
+      {{- with .Values.sinks.metadata.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: sinks

--- a/charts/orb/templates/things-deployment.yaml
+++ b/charts/orb/templates/things-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       component: things
   template:
     metadata:
+      {{- with .Values.things.metadata.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: things

--- a/charts/orb/templates/ui-deployment.yaml
+++ b/charts/orb/templates/ui-deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       annotations:
         commit_sha: {{ .Values.defaults.image.commitHash }}
+      {{- with .Values.ui.metadata.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: ui

--- a/charts/orb/templates/users-deployment.yaml
+++ b/charts/orb/templates/users-deployment.yaml
@@ -19,6 +19,10 @@ spec:
       component: users
   template:
     metadata:
+      {{- with .Values.users.metadata.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: users

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -57,6 +57,8 @@ users:
     secretName: orb-user-service
     emailSecretKey: adminEmail
     passwordSecretKey: adminPassword
+  metadata:
+    annotations: { }
 
 fleet:
   image: { }
@@ -65,6 +67,8 @@ fleet:
   grpcPort: 8283
   httpPort: 8203
   redisESPort: 6379
+  metadata:
+    annotations: { }
 
 policies:
   image: { }
@@ -73,6 +77,8 @@ policies:
   grpcPort: 8282
   httpPort: 8202
   redisESPort: 6379
+  metadata:
+    annotations: { }
 
 sinks:
   image: { }
@@ -81,11 +87,15 @@ sinks:
   grpcPort: 8280
   httpPort: 8200
   redisESPort: 6379
+  metadata:
+    annotations: { }
 
 sinker:
   image: { }
   httpPort: 8201
   redisESPort: 6379
+  metadata:
+    annotations: { }
 
 things:
   image: { }
@@ -95,6 +105,8 @@ things:
   authHttpPort: 8989
   redisESPort: 6379
   redisCachePort: 6379
+  metadata:
+    annotations: { }
 
 auth:
   image: { }
@@ -104,11 +116,15 @@ auth:
   jwt:
     secretName: orb-auth-service
     secretKey: jwtSecret
+  metadata:
+    annotations: { }
 
 ui:
   image:
     name: orb-ui
   port: 3000
+  metadata:
+    annotations: { }
 
 nats:
   auth:


### PR DESCRIPTION
This PR is changes:
- Added possibility to inject annotations on following pods:
auth, users, things, fleet, sinks, policies, sinker.