### PR TITLE
[FIX] adding possibility to disable depencies if needed

### DIFF
--- a/charts/orb/Chart.lock
+++ b/charts/orb/Chart.lock
@@ -32,5 +32,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 14.8.8
-digest: sha256:0757bc4dd1a0398947fcd6ec3287e3e162273769e724378ce2dc25881876469e
-generated: "2021-09-03T12:24:22.687884-04:00"
+digest: sha256:a8b2eed928c6e3d7daf2b2f7935e8fbb2f131face080b02437b7bf0d088fd0eb
+generated: "2022-03-19T16:01:31.148079018-03:00"

--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -10,7 +10,7 @@ name: orb
 description: Orb Observability Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 1.0.12
+version: 1.0.13
 appVersion: "0.9.0"
 home: https://getorb.io
 sources:

--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -70,6 +70,6 @@ dependencies:
   - name: redis
     version: "14.8.8"
     repository: "@bitnami"
-    alias: redis-mqtt
+    alias:
     condition: redis-mqtt.enabled
 

--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -23,6 +23,7 @@ dependencies:
   - name: jaeger-operator
     version: "2.23.0"
     repository: "@jaegertracing"
+    condition: jaeger-operator.enabled
   - name: nats
     version: "6.4.2"
     repository: "@bitnami"
@@ -30,36 +31,45 @@ dependencies:
     version: "10.9.1"
     repository: "@bitnami"
     alias: postgresql-fleet
+    condition: postgresql-fleet.enabled
   - name: postgresql
     version: "10.9.1"
     repository: "@bitnami"
     alias: postgresql-policies
+    condition: postgresql-policies.enabled
   - name: postgresql
     version: "10.9.1"
     repository: "@bitnami"
     alias: postgresql-sinks
+    condition: postgresql-sinks.enabled
   - name: postgresql
     version: "10.9.1"
     repository: "@bitnami"
     alias: postgresql-things
+    condition: postgresql-things.enabled
   - name: postgresql
     version: "10.9.1"
     repository: "@bitnami"
     alias: postgresql-users
+    condition: postgresql-users.enabled
   - name: postgresql
     version: "10.9.1"
     repository: "@bitnami"
     alias: postgresql-auth
+    condition: postgresql-auth.enabled
   - name: redis
     version: "14.8.8"
     repository: "@bitnami"
     alias: redis-streams
+    condition: redis-streams.enabled
   - name: redis
     version: "14.8.8"
     repository: "@bitnami"
     alias: redis-auth
+    condition: redis-auth.enabled
   - name: redis
     version: "14.8.8"
     repository: "@bitnami"
     alias: redis-mqtt
+    condition: redis-mqtt.enabled
 

--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -70,6 +70,6 @@ dependencies:
   - name: redis
     version: "14.8.8"
     repository: "@bitnami"
-    alias:
+    alias: redis-mqtt
     condition: redis-mqtt.enabled
 

--- a/charts/orb/templates/adapter_mqtt-statefulstet.yaml
+++ b/charts/orb/templates/adapter_mqtt-statefulstet.yaml
@@ -174,8 +174,11 @@ spec:
             - name: MF_MQTT_ADAPTER_WS_PORT
               value: "{{ .Values.mqtt.adapter.wsPort }}"
             - name: MF_MQTT_ADAPTER_ES_URL
-              value:
-                {{ .Release.Name }}-redis-streams-master:{{ .Values.mqtt.redisESPort }}
+            {{ if not .Values.mqtt.redisESHost }}
+              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.mqtt.redisESPort }}
+            {{ else }}
+              value: {{ .Values.mqtt.redisESHost }}:{{ .Values.mqtt.redisESPort }}
+            {{ end }}
             - name: MF_NATS_URL
               value:
                 nats://{{ .Release.Name }}-nats-client:{{ .Values.defaults.natsPort }}
@@ -199,8 +202,11 @@ spec:
             - name: MF_MQTT_ADAPTER_THINGS_TIMEOUT
               value: "15"
             - name: MF_AUTH_CACHE_URL
-              value:
-                {{ .Release.Name }}-redis-auth-master:{{ .Values.mqtt.redisCachePort }}
+            {{ if not .Values.mqtt.redisCacheHost }}
+              value: {{ .Release.Name }}-redis-auth-master:{{ .Values.mqtt.redisCachePort }}
+            {{ else }}
+              value: {{ .Values.mqtt.redisCacheHost }}:{{ .Values.mqtt.redisCachePort }}
+            {{ end }}
             - name: MF_MQTT_ADAPTER_MQTT_TARGET_HEALTH_CHECK
               value: http://localhost:8888/health
           livenessProbe:

--- a/charts/orb/templates/auth-deployment.yaml
+++ b/charts/orb/templates/auth-deployment.yaml
@@ -32,7 +32,11 @@ spec:
             - name: MF_AUTH_DB
               value: {{ index .Values "postgresql-auth" "postgresqlDatabase" }}
             - name: MF_AUTH_DB_HOST
+            {{ if not .Values.auth.dbHost }}
               value: {{ .Release.Name }}-postgresql-auth
+            {{ else }}
+              value: {{ .Values.auth.dbHost }}
+            {{ end }}
             - name: MF_AUTH_DB_PASS
               value: {{ index .Values "postgresql-auth" "postgresqlPassword" }}
             - name: MF_AUTH_DB_PORT

--- a/charts/orb/templates/fleet-deployment.yaml
+++ b/charts/orb/templates/fleet-deployment.yaml
@@ -33,7 +33,11 @@ spec:
             - name: ORB_FLEET_DB
               value: {{ index .Values "postgresql-fleet" "postgresqlDatabase" }}
             - name: ORB_FLEET_DB_HOST
+            {{ if not .Values.fleet.dbHost }}
               value: {{ .Release.Name }}-postgresql-fleet
+            {{ else }}
+              value: {{ .Values.fleet.dbHost }}
+            {{ end }}
             - name: ORB_FLEET_DB_PASS
               value: {{ index .Values "postgresql-fleet" "postgresqlPassword" }}
             - name: ORB_FLEET_DB_PORT
@@ -43,8 +47,11 @@ spec:
             - name: ORB_FLEET_DB_USER
               value: {{ index .Values "postgresql-fleet" "postgresqlUsername" }}
             - name: ORB_FLEET_ES_URL
-              value:
-                {{ .Release.Name }}-redis-streams-master:{{ .Values.fleet.redisESPort }}
+            {{ if not .Values.fleet.redisESHost }}
+              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.fleet.redisESPort }}
+            {{ else }}
+              value: {{ .Values.fleet.redisESHost }}:{{ .Values.fleet.redisESPort }}
+            {{ end }}
             - name: ORB_FLEET_GRPC_PORT
               value: "{{ .Values.fleet.grpcPort }}"
             - name: ORB_FLEET_HTTP_PORT

--- a/charts/orb/templates/policies-deployment.yaml
+++ b/charts/orb/templates/policies-deployment.yaml
@@ -33,7 +33,11 @@ spec:
             - name: ORB_POLICIES_DB
               value: {{ index .Values "postgresql-policies" "postgresqlDatabase" }}
             - name: ORB_POLICIES_DB_HOST
+            {{ if not .Values.policies.dbHost }}
               value: {{ .Release.Name }}-postgresql-policies
+            {{ else }}
+              value: {{ .Values.policies.dbHost }}
+            {{ end }}
             - name: ORB_POLICIES_DB_PASS
               value: {{ index .Values "postgresql-policies" "postgresqlPassword" }}
             - name: ORB_POLICIES_DB_PORT
@@ -43,8 +47,11 @@ spec:
             - name: ORB_POLICIES_DB_USER
               value: {{ index .Values "postgresql-policies" "postgresqlUsername" }}
             - name: ORB_POLICIES_ES_URL
-              value:
-                {{ .Release.Name }}-redis-streams-master:{{ .Values.policies.redisESPort }}
+            {{ if not .Values.policies.redisESHost }}
+              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.policies.redisESPort }}
+            {{ else }}
+              value: {{ .Values.policies.redisESHost }}:{{ .Values.policies.redisESPort }}
+            {{ end }}
             - name: ORB_FLEET_GRPC_URL
               value:
                 {{ .Release.Name }}-envoy:{{ .Values.fleet.grpcPort }}

--- a/charts/orb/templates/sinker-deployment.yaml
+++ b/charts/orb/templates/sinker-deployment.yaml
@@ -31,8 +31,11 @@ spec:
               value: {{ .Values.defaults.jaegerHost }}:{{ .Values.defaults.jaegerPort }}
             {{ end }}
             - name: ORB_SINKER_ES_URL
-              value:
-                {{ .Release.Name }}-redis-streams-master:{{ .Values.sinker.redisESPort }}
+            {{ if not .Values.sinker.redisESHost }}
+              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.sinker.redisESPort }}
+            {{ else }}
+              value: {{ .Values.sinker.redisESHost }}:{{ .Values.sinker.redisESPort }}
+            {{ end }}
             - name: ORB_FLEET_GRPC_URL
               value:
                 {{ .Release.Name }}-envoy:{{ .Values.fleet.grpcPort }}

--- a/charts/orb/templates/sinks-deployment.yaml
+++ b/charts/orb/templates/sinks-deployment.yaml
@@ -33,7 +33,11 @@ spec:
             - name: ORB_SINKS_DB
               value: {{ index .Values "postgresql-sinks" "postgresqlDatabase" }}
             - name: ORB_SINKS_DB_HOST
+            {{ if not .Values.sinks.dbHost }}
               value: {{ .Release.Name }}-postgresql-sinks
+            {{ else }}
+              value: {{ .Values.sinks.dbHost }}
+            {{ end }}
             - name: ORB_SINKS_DB_PASS
               value: {{ index .Values "postgresql-sinks" "postgresqlPassword" }}
             - name: ORB_SINKS_DB_PORT
@@ -45,8 +49,11 @@ spec:
             - name: ORB_SINKS_GRPC_PORT
               value: "{{ .Values.sinks.grpcPort }}"
             - name: ORB_SINKS_ES_URL
-              value:
-                {{ .Release.Name }}-redis-streams-master:{{ .Values.sinks.redisESPort }}
+            {{ if not .Values.sinks.redisESHost }}
+              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.sinks.redisESPort }}
+            {{ else }}
+              value: {{ .Values.sinks.redisESHost }}:{{ .Values.sinks.redisESPort }}
+            {{ end }}
             - name: ORB_SINKS_HTTP_PORT
               value: "{{ .Values.sinks.httpPort }}"
             - name: ORB_SINKS_LOG_LEVEL

--- a/charts/orb/templates/things-deployment.yaml
+++ b/charts/orb/templates/things-deployment.yaml
@@ -34,12 +34,19 @@ spec:
             - name: MF_THINGS_AUTH_HTTP_PORT
               value: "{{ .Values.things.authHttpPort }}"
             - name: MF_THINGS_CACHE_URL
-              value:
-                {{ .Release.Name }}-redis-auth-master:{{ .Values.things.redisCachePort }}
+            {{ if not .Values.things.redisCacheHost }}
+              value: {{ .Release.Name }}-redis-auth-master:{{ .Values.things.redisCachePort }}
+            {{ else }}
+              value: {{ .Values.things.redisCacheHost }}:{{ .Values.things.redisCachePort }}
+            {{ end }}
             - name: MF_THINGS_DB
               value: {{ index .Values "postgresql-things" "postgresqlDatabase" }}
             - name: MF_THINGS_DB_HOST
+            {{ if not .Values.things.dbHost }}
               value: {{ .Release.Name }}-postgresql-things
+            {{ else }}
+              value: {{ .Values.things.dbHost }}
+            {{ end }}
             - name: MF_THINGS_DB_PASS
               value: {{ index .Values "postgresql-things" "postgresqlPassword" }}
             - name: MF_THINGS_DB_PORT
@@ -47,8 +54,11 @@ spec:
             - name: MF_THINGS_DB_USER
               value: {{ index .Values "postgresql-things" "postgresqlUsername" }}
             - name: MF_THINGS_ES_URL
-              value:
-                {{ .Release.Name }}-redis-streams-master:{{ .Values.things.redisESPort }}
+            {{ if not .Values.things.redisESHost }}
+              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.things.redisESPort }}
+            {{ else }}
+              value: {{ .Values.things.redisESHost }}:{{ .Values.things.redisESPort }}
+            {{ end }}
             - name: MF_THINGS_HTTP_PORT
               value: "{{ .Values.things.httpPort }}"
             - name: MF_THINGS_LOG_LEVEL

--- a/charts/orb/templates/users-deployment.yaml
+++ b/charts/orb/templates/users-deployment.yaml
@@ -38,7 +38,11 @@ spec:
             - name: MF_USERS_DB
               value: {{ index .Values "postgresql-users"  "postgresqlDatabase" }}
             - name: MF_USERS_DB_HOST
+            {{ if not .Values.users.dbHost }}
               value: {{ .Release.Name }}-postgresql-users
+            {{ else }}
+              value: {{ .Values.users.dbHost }}
+            {{ end }}
             - name: MF_USERS_DB_PASS
               value: {{ index .Values "postgresql-users" "postgresqlPassword" }}
             - name: MF_USERS_DB_PORT

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -242,7 +242,7 @@ redis-auth:
       enabled: false
 
 jaeger-operator:
-  enabled: false
+  enabled: true
   jaeger:
     create: true
   rbac:

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -48,11 +48,14 @@ mqtt:
     persistentVolume:
       size: 5Gi
   redisESPort: 6379
+  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
   redisCachePort: 6379
+  redisCacheHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
 
 users:
   image: { }
   dbPort: 5432
+  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
   httpPort: 8180
   admin:
     secretName: orb-user-service
@@ -64,9 +67,11 @@ users:
 fleet:
   image: { }
   dbPort: 5432
+  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
   dbSSL: "disable"
   grpcPort: 8283
   httpPort: 8203
+  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
   redisESPort: 6379
   metadata:
     annotations: { }
@@ -74,20 +79,24 @@ fleet:
 policies:
   image: { }
   dbPort: 5432
+  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
   dbSSL: "disable"
   grpcPort: 8282
   httpPort: 8202
   redisESPort: 6379
+  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
 sinks:
   image: { }
   dbPort: 5432
+  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
   dbSSL: "disable"
   grpcPort: 8280
   httpPort: 8200
   redisESPort: 6379
+  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
@@ -95,23 +104,28 @@ sinker:
   image: { }
   httpPort: 8201
   redisESPort: 6379
+  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
 things:
   image: { }
   dbPort: 5432
+  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
   httpPort: 8182
   authGrpcPort: 8183
   authHttpPort: 8989
   redisESPort: 6379
+  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
   redisCachePort: 6379
+  redisCacheHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
 auth:
   image: { }
   dbPort: 5432
+  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
   grpcPort: 8181
   httpPort: 8189
   jwt:
@@ -136,7 +150,7 @@ nats:
   replicaCount: 3
 
 postgresql-users:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   name: postgresql-users
   postgresqlUsername: postgres
   postgresqlPassword: mainflux
@@ -148,7 +162,7 @@ postgresql-users:
     size: 1Gi
 
 postgresql-fleet:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   name: postgresql-fleet
   image:
     tag: 13
@@ -162,7 +176,7 @@ postgresql-fleet:
     size: 1Gi
 
 postgresql-policies:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   name: postgresql-policies
   image:
     tag: 13
@@ -176,7 +190,7 @@ postgresql-policies:
     size: 1Gi
 
 postgresql-sinks:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   name: postgresql-sinks
   image:
     tag: 13
@@ -190,7 +204,7 @@ postgresql-sinks:
     size: 1Gi
 
 postgresql-things:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   name: postgresql-things
   postgresqlUsername: postgres
   postgresqlPassword: mainflux
@@ -202,7 +216,7 @@ postgresql-things:
     size: 1Gi
 
 postgresql-auth:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   name: postgresql-auth
   postgresqlUsername: postgres
   postgresqlPassword: mainflux
@@ -214,7 +228,7 @@ postgresql-auth:
     size: 1Gi
 
 redis-streams:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   volumePermissions:
     enabled: true
   cluster:
@@ -223,7 +237,7 @@ redis-streams:
     enabled: false
 
 redis-mqtt:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   volumePermissions:
     enabled: true
   cluster:
@@ -232,7 +246,7 @@ redis-mqtt:
     enabled: false
 
 redis-auth:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   cluster:
     enabled: false
   auth:
@@ -242,7 +256,7 @@ redis-auth:
       enabled: false
 
 jaeger-operator:
-  enabled: true
+  enabled: true # dependency install, disable if you want to use external services
   jaeger:
     create: true
   rbac:

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -48,14 +48,14 @@ mqtt:
     persistentVolume:
       size: 5Gi
   redisESPort: 6379
-  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
+  redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
   redisCachePort: 6379
-  redisCacheHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
+  redisCacheHost: "" # Set this field with host if you want to point to external database such as Elasticache
 
 users:
   image: { }
   dbPort: 5432
-  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
+  dbHost: "" # Set this field with host if you want to point to external database such as RDS
   httpPort: 8180
   admin:
     secretName: orb-user-service
@@ -67,11 +67,11 @@ users:
 fleet:
   image: { }
   dbPort: 5432
-  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
+  dbHost: "" # Set this field with host if you want to point to external database such as RDS
   dbSSL: "disable"
   grpcPort: 8283
   httpPort: 8203
-  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
+  redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
   redisESPort: 6379
   metadata:
     annotations: { }
@@ -79,24 +79,24 @@ fleet:
 policies:
   image: { }
   dbPort: 5432
-  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
+  dbHost: "" # Set this field with host if you want to point to external database such as RDS
   dbSSL: "disable"
   grpcPort: 8282
   httpPort: 8202
   redisESPort: 6379
-  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
+  redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
 sinks:
   image: { }
   dbPort: 5432
-  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
+  dbHost: "" # Set this field with host if you want to point to external database such as RDS
   dbSSL: "disable"
   grpcPort: 8280
   httpPort: 8200
   redisESPort: 6379
-  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
+  redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
@@ -104,28 +104,28 @@ sinker:
   image: { }
   httpPort: 8201
   redisESPort: 6379
-  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
+  redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
 things:
   image: { }
   dbPort: 5432
-  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
+  dbHost: "" # Set this field with host if you want to point to external database such as RDS
   httpPort: 8182
   authGrpcPort: 8183
   authHttpPort: 8989
   redisESPort: 6379
-  redisESHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
+  redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
   redisCachePort: 6379
-  redisCacheHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as Elasticache
+  redisCacheHost: "" # Set this field with host if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
 auth:
   image: { }
   dbPort: 5432
-  dbHost: "" # disable "dependency install" and set field with host this if you want to point to external database such as RDS
+  dbHost: "" # Set this field with host if you want to point to external database such as RDS
   grpcPort: 8181
   httpPort: 8189
   jwt:

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -136,6 +136,7 @@ nats:
   replicaCount: 3
 
 postgresql-users:
+  enabled: true
   name: postgresql-users
   postgresqlUsername: postgres
   postgresqlPassword: mainflux
@@ -147,6 +148,7 @@ postgresql-users:
     size: 1Gi
 
 postgresql-fleet:
+  enabled: true
   name: postgresql-fleet
   image:
     tag: 13
@@ -160,6 +162,7 @@ postgresql-fleet:
     size: 1Gi
 
 postgresql-policies:
+  enabled: true
   name: postgresql-policies
   image:
     tag: 13
@@ -173,6 +176,7 @@ postgresql-policies:
     size: 1Gi
 
 postgresql-sinks:
+  enabled: true
   name: postgresql-sinks
   image:
     tag: 13
@@ -186,6 +190,7 @@ postgresql-sinks:
     size: 1Gi
 
 postgresql-things:
+  enabled: true
   name: postgresql-things
   postgresqlUsername: postgres
   postgresqlPassword: mainflux
@@ -197,6 +202,7 @@ postgresql-things:
     size: 1Gi
 
 postgresql-auth:
+  enabled: true
   name: postgresql-auth
   postgresqlUsername: postgres
   postgresqlPassword: mainflux
@@ -208,6 +214,7 @@ postgresql-auth:
     size: 1Gi
 
 redis-streams:
+  enabled: true
   volumePermissions:
     enabled: true
   cluster:
@@ -216,6 +223,7 @@ redis-streams:
     enabled: false
 
 redis-mqtt:
+  enabled: true
   volumePermissions:
     enabled: true
   cluster:
@@ -224,6 +232,7 @@ redis-mqtt:
     enabled: false
 
 redis-auth:
+  enabled: true
   cluster:
     enabled: false
   auth:
@@ -233,6 +242,7 @@ redis-auth:
       enabled: false
 
 jaeger-operator:
+  enabled: false
   jaeger:
     create: true
   rbac:


### PR DESCRIPTION
This PR changes:
- Adding conditions to control dependencies installation on kubernetes such as jaeger-operator, redis and postgres databases. 
- Adding variables to permit host control on redis and postgres database on all pods, looking to be ready for externalize databases

This is an improvement to disable local dependencies installation and preparing for use of external services such as RDS, Elasticache.