### PR TITLE
[FIX] add changes for orb-live

### DIFF
--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -10,7 +10,7 @@ name: orb
 description: Orb Observability Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 1.0.13
+version: 1.0.14
 appVersion: "0.9.0"
 home: https://getorb.io
 sources:
@@ -70,6 +70,6 @@ dependencies:
   - name: redis
     version: "14.8.8"
     repository: "@bitnami"
-    alias: redis-mqtt
-    condition: redis-mqtt.enabled
+    alias: redis-sinker
+    condition: redis-sinker.enabled
 

--- a/charts/orb/templates/auth-deployment.yaml
+++ b/charts/orb/templates/auth-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.auth.jwt.secretName }}
                   key: {{ .Values.auth.jwt.secretKey }}
-          image: "{{ default .Values.defaults.image.mfRepository .Values.auth.image.repository }}/auth:{{ default .Values.defaults.image.mfTag .Values.auth.image.tag }}"
+          image: "{{ default .Values.defaults.image.repository .Values.auth.image.repository }}/{{ default .Values.auth.image.name }}:{{ default .Values.defaults.image.tag .Values.auth.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.users.image.pullPolicy }}
           name: {{ .Release.Name }}-auth
           ports:

--- a/charts/orb/templates/fleet-deployment.yaml
+++ b/charts/orb/templates/fleet-deployment.yaml
@@ -71,7 +71,7 @@ spec:
               value:
                 http://{{ .Release.Name }}-things:{{ .Values.things.httpPort }}
 
-          image: "{{ default .Values.defaults.image.repository }}/orb-fleet:{{ default .Values.defaults.image.tag }}"
+          image: "{{ default .Values.defaults.image.repository .Values.fleet.image.repository }}/{{ default .Values.fleet.image.name }}:{{ default .Values.defaults.image.tag .Values.fleet.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.fleet.image.pullPolicy }}
           name: {{ .Release.Name }}-fleet
           ports:

--- a/charts/orb/templates/policies-deployment.yaml
+++ b/charts/orb/templates/policies-deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: MF_AUTH_GRPC_URL
               value:
                 {{ .Release.Name }}-envoy:{{ .Values.auth.grpcPort }}
-          image: "{{ default .Values.defaults.image.repository }}/orb-policies:{{ default .Values.defaults.image.tag }}"
+          image: "{{ default .Values.defaults.image.repository .Values.policies.image.repository }}/{{ default .Values.policies.image.name }}:{{ default .Values.defaults.image.tag .Values.policies.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.policies.image.pullPolicy }}
           name: {{ .Release.Name }}-policies
           ports:

--- a/charts/orb/templates/sinker-deployment.yaml
+++ b/charts/orb/templates/sinker-deployment.yaml
@@ -32,9 +32,15 @@ spec:
             {{ end }}
             - name: ORB_SINKER_ES_URL
             {{ if not .Values.sinker.redisESHost }}
-              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.sinker.redisESPort }}
+            value: {{ .Release.Name }}-redis-streams-master:{{ .Values.sinker.redisESPort }}
             {{ else }}
-              value: {{ .Values.sinker.redisESHost }}:{{ .Values.sinker.redisESPort }}
+            value: {{ .Values.sinker.redisESHost }}:{{ .Values.sinker.redisESPort }}
+            {{ end }}
+            - name: ORB_SINKER_CACHE_URL
+            {{ if not .Values.sinker.redisCacheHost }}
+              value: {{ .Release.Name }}-redis-sinker-master:{{ .Values.sinker.redisCachePort }}
+            {{ else }}
+              value: {{ .Values.sinker.redisCacheHost }}:{{ .Values.sinker.redisCachePort }}
             {{ end }}
             - name: ORB_FLEET_GRPC_URL
               value:
@@ -55,7 +61,7 @@ spec:
             - name: MF_AUTH_GRPC_URL
               value:
                 {{ .Release.Name }}-envoy:{{ .Values.auth.grpcPort }}
-          image: "{{ default .Values.defaults.image.repository }}/orb-sinker:{{ default .Values.defaults.image.tag }}"
+          image: "{{ default .Values.defaults.image.repository .Values.sinker.image.repository }}/{{ default .Values.sinker.image.name }}:{{ default .Values.defaults.image.tag .Values.sinker.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.sinker.image.pullPolicy }}
           name: {{ .Release.Name }}-sinker
           ports:

--- a/charts/orb/templates/sinks-deployment.yaml
+++ b/charts/orb/templates/sinks-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: MF_AUTH_GRPC_URL
               value:
                 {{ .Release.Name }}-envoy:{{ .Values.auth.grpcPort }}
-          image: "{{ default .Values.defaults.image.repository }}/orb-sinks:{{ default .Values.defaults.image.tag }}"
+          image: "{{ default .Values.defaults.image.repository .Values.sinks.image.repository }}/{{ default .Values.sinks.image.name }}:{{ default .Values.defaults.image.tag .Values.sinks.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.sinks.image.pullPolicy }}
           name: {{ .Release.Name }}-sinks
           ports:

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -105,6 +105,8 @@ sinker:
   httpPort: 8201
   redisESPort: 6379
   redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
+  redisCachePort: 6379
+  redisCacheHost: "" # Set this field with host if you want to point to external database such as Elasticache
   metadata:
     annotations: { }
 
@@ -236,7 +238,7 @@ redis-streams:
   auth:
     enabled: false
 
-redis-mqtt:
+redis-sinker:
   enabled: true # dependency install, disable if you want to use external services
   volumePermissions:
     enabled: true


### PR DESCRIPTION
This PR changes:
- Changing name of redis-mqtt to redis-sinker to be used by last sinker version
- Setting exact images tag on deployments using values instead default values
