### PR TITLE
Add missing image names for Orb images to values.yaml

### DIFF
--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -69,7 +69,8 @@ users:
     annotations: { }
 
 fleet:
-  image: { }
+  image:
+    name: "orb-fleet"
   dbPort: 5432
   dbHost: "" # Set this field with host if you want to point to external database such as RDS
   dbSSL: "disable"
@@ -81,7 +82,8 @@ fleet:
     annotations: { }
 
 policies:
-  image: { }
+  image:
+    name: "orb-policies"
   dbPort: 5432
   dbHost: "" # Set this field with host if you want to point to external database such as RDS
   dbSSL: "disable"
@@ -93,7 +95,8 @@ policies:
     annotations: { }
 
 sinks:
-  image: { }
+  image:
+    name: "orb-sinks"
   dbPort: 5432
   dbHost: "" # Set this field with host if you want to point to external database such as RDS
   dbSSL: "disable"
@@ -105,7 +108,8 @@ sinks:
     annotations: { }
 
 sinker:
-  image: { }
+  image:
+    name: "orb-sinker"
   httpPort: 8201
   redisESPort: 6379
   redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache


### PR DESCRIPTION
These seem to be the default images for Orb. Please correct them if wrong.