### PR TITLE
Add ability to configure ingress class and annotations

### DIFF
--- a/charts/orb/templates/ingress.yaml
+++ b/charts/orb/templates/ingress.yaml
@@ -4,11 +4,13 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+{{- if .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    cert-manager.io/issuer: {{ .Values.ingress.issuer }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
   name: {{ .Release.Name }}-nginx-ingress
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
     - host: {{ required "an ingress.hostname is required!" .Values.ingress.hostname }}
       http:
@@ -35,12 +37,13 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+{{- if .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    cert-manager.io/issuer: {{ .Values.ingress.issuer }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
   name: {{ .Release.Name }}-nginx-rewrite-ingress
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
     - host: "{{ .Values.ingress.hostname }}"
       http:

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -25,7 +25,10 @@ smtp:
   fromName: Orb
 
 ingress:
-  issuer: "letsencrypt-prod"
+  ingressClassName: "nginx"
+  annotations:
+    cert-manager.io/issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
   hostname: ""
   secret: "orb-tls"
 


### PR DESCRIPTION
These changes allow for overriding the Ingress class and setting other annotations in a custom way, such as the Cert Manager Issuer.