### PR TITLE
[FIX] permit annotations on mqtt statefulset

### DIFF
--- a/charts/orb/Chart.yaml
+++ b/charts/orb/Chart.yaml
@@ -10,8 +10,8 @@ name: orb
 description: Orb Observability Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 1.0.17
-appVersion: "0.14.0"
+version: 1.0.18
+appVersion: "0.16.0"
 home: https://getorb.io
 sources:
   - https://hub.docker.com/u/ns1labs/

--- a/charts/orb/templates/adapter_mqtt-statefulstet.yaml
+++ b/charts/orb/templates/adapter_mqtt-statefulstet.yaml
@@ -47,6 +47,10 @@ spec:
       component: mqtt
   template:
     metadata:
+      annotations:
+      {{- with .Values.mqtt.metadata.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name}}
         component: mqtt

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -56,6 +56,8 @@ mqtt:
   redisESHost: "" # Set this field with host if you want to point to external database such as Elasticache
   redisCachePort: 6379
   redisCacheHost: "" # Set this field with host if you want to point to external database such as Elasticache
+  metadata:
+    annotations: { }
 
 users:
   image:


### PR DESCRIPTION
This PR changes:
- Permit add annotations on mqtt statefulset to scrap metrics using prometheus