### PR TITLE
[FIX] add annotations on envoy service

### DIFF
--- a/charts/orb/templates/envoy.yaml
+++ b/charts/orb/templates/envoy.yaml
@@ -4,6 +4,12 @@
 apiVersion: v1
 data:
   envoy-config-yaml: |-
+    admin:
+      access_log_path: /tmp/admin_access.log
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9901
     static_resources:
       listeners:
         - name: mqtt_listener

--- a/charts/orb/templates/envoy.yaml
+++ b/charts/orb/templates/envoy.yaml
@@ -263,7 +263,7 @@ spec:
     metadata:
       annotations:
       {{- with .Values.envoy.metadata.annotations }}
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         app: {{ .Release.Name }}

--- a/charts/orb/templates/envoy.yaml
+++ b/charts/orb/templates/envoy.yaml
@@ -5,7 +5,6 @@ apiVersion: v1
 data:
   envoy-config-yaml: |-
     admin:
-      access_log_path: /tmp/admin_access.log
       address:
         socket_address:
           address: 0.0.0.0

--- a/charts/orb/templates/envoy.yaml
+++ b/charts/orb/templates/envoy.yaml
@@ -284,6 +284,8 @@ spec:
               protocol: TCP
             - containerPort: 8001
               protocol: TCP
+            - containerPort: 9901
+              protocol: TCP
           volumeMounts:
             - mountPath: /etc/envoy
               name: envoy-config
@@ -325,3 +327,6 @@ spec:
     - port: 8001
       protocol: TCP
       name: admin
+    - port: 9901
+      protocol: TCP
+      name: metrics

--- a/charts/orb/templates/envoy.yaml
+++ b/charts/orb/templates/envoy.yaml
@@ -256,6 +256,10 @@ spec:
       component: envoy
   template:
     metadata:
+      annotations:
+      {{- with .Values.envoy.metadata.annotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}
         component: envoy

--- a/charts/orb/values.yaml
+++ b/charts/orb/values.yaml
@@ -289,6 +289,8 @@ envoy:
     pullPolicy: "IfNotPresent"
     repository: "envoyproxy/envoy"
     tag: "v1.19.1"
+  metadata:
+    annotations: { }
 
 nginx_internal:
   image:


### PR DESCRIPTION
This PR changes:
- add annotations on envoy pod to permit prometheus collect metrics from it
- add configurations to expose admin interface endpoint to access metrics